### PR TITLE
added reset button

### DIFF
--- a/src/Synferno_15/Button.h
+++ b/src/Synferno_15/Button.h
@@ -7,6 +7,7 @@
 
 // pins
 #define BUTTON_PIN1 7
+#define BUTTON_PIN2 12
 
 class Button{
   public:

--- a/src/Synferno_15/MIDI.cpp
+++ b/src/Synferno_15/MIDI.cpp
@@ -54,6 +54,10 @@ byte MIDI::getCounter() {
   return ( clockCounter );
 }
 
+void MIDI::resetCounter() {
+  clockCounter = 0;
+}
+
 void MIDI::processTick() {
   // increment the clock
   clockCounter = (clockCounter + 1) % MIDI_CLOCKS_PER_BEAT;

--- a/src/Synferno_15/MIDI.h
+++ b/src/Synferno_15/MIDI.h
@@ -32,6 +32,8 @@ class MIDI{
 
     byte getCounter(); // 0-23 ticks
 
+    void resetCounter(); // set counter back to 0
+
     unsigned long tickLength(); // length of ticks, uS
     unsigned long beatLength();  // length of 24 ticks (one beat), ms
     

--- a/src/Synferno_15/Synferno_15.ino
+++ b/src/Synferno_15/Synferno_15.ino
@@ -26,6 +26,7 @@ Potentiometer duration, offset, frequency, options;
 // Fire button
 #include "Button.h"
 Button makeFireNow;
+Button resetCounter;
 
 void setup() {
   Serial.begin(115200);
@@ -60,6 +61,7 @@ void setup() {
   // buttons
   makeFireNow.begin(BUTTON_PIN1);
   showMakeFireNow(makeFireNow.getState());
+  resetCounter.begin(BUTTON_PIN2);
 }
 
 void loop() {
@@ -79,6 +81,11 @@ void loop() {
   if ( frequency.update() ) {
     // have a change in frequency
     showFrequency(map(frequency.getSector(), 0, FREQUENCY_SECTORS-1, 0 - ((FREQUENCY_SECTORS -1) / 2), (FREQUENCY_SECTORS-1) / 2));
+  }
+  if (resetCounter.update() && resetCounter.getState()) {
+    // reset button has just been pressed.  Reset the MIDI clock.
+    Serial << F("reset counter") << endl;
+    midi.resetCounter();
   }
 
   // 2. decode the MIDI situation
@@ -118,7 +125,6 @@ void loop() {
     // report tick, noting we do this after the hardware-level update
     showMIDI(midi.getCounter());
   }
-
 
   // 3. override with the Make Fire Now button
   if ( makeFireNow.update() ) {
@@ -353,4 +359,3 @@ void showCounter(byte row, byte col, int counter) {
   if ( oled.buffer.length() < 2 ) oled.buffer += " ";
   oled.write(row, col); // don't pad, place at a specific location
 }
-


### PR DESCRIPTION
Added a momentary push button to reset the midi clock.

When the audio source changes to a different tempo, the downbeat falls out of sync with the midi counter.  This button can be pressed to reset the midi clock and thus realign with the downbeat.